### PR TITLE
feat: opt-in age encryption for save and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ the progress output match the rest of the desktop.
 imprint save                         # picker, writes ~/imprints/imprint-$host-$time.tar.zst
 imprint save --only look,bar,plugins
 imprint save --all -o /mnt/usb/dex.imprint.tar.zst
+imprint save --encrypt -o FILE       # encrypt the archive with age
 
 imprint restore FILE                 # picker of what is in that file
+imprint restore FILE --identity ~/.config/age/backup-key.txt   # decrypt an encrypted archive
 imprint restore FILE --only bar,plugins --dry-run
 imprint restore FILE --only identity --confirm-hostname dex
 imprint restore FILE --upgrade       # omarchy update -y first, abort if it fails
@@ -122,6 +124,37 @@ imprint list
 
 The archive is self-contained. On a fresh Omarchy install you can extract it
 and run `tool/imprint restore .` without installing anything first.
+
+## Encrypting archives
+
+An imprint carries configs, shell history and identity data, and it is often
+copied to a USB stick or relayed through a chat. `--encrypt` wraps the finished
+archive with [age](https://github.com/FiloSottile/age) so only the holder of
+the matching key can read it:
+
+```bash
+imprint save --encrypt -o ~/imprints/imprint-dex.tar.zst
+# writes imprint-dex.tar.zst.age and removes the plaintext
+
+imprint save --encrypt -r age1... -o FILE   # encrypt to a specific recipient
+imprint save --encrypt --keep-plaintext     # keep the .tar.zst alongside
+```
+
+The recipient is your explicit `-r`, or `~/.config/age/backup-key.pub` if it
+exists. With neither, save stops and says what to do:
+
+```
+no age recipient found; run age-keygen -o backup-key.txt
+```
+
+`imprint restore`, `info`, `plan`, `preview`, `verify` and `diff` all detect a
+`.tar.zst.age` and decrypt it with `~/.config/age/backup-key.txt` (or
+`--identity FILE` on restore) before doing their normal work. A missing key is
+a clean error, not a traceback.
+
+`age` is not a hard dependency — it is only needed when you use `--encrypt` or
+restore an encrypted archive. Install it with `pacman -S age` (or
+`mise use age`); `age-keygen` ships with it.
 
 ## What a run looks like
 

--- a/imprint
+++ b/imprint
@@ -105,6 +105,7 @@ Usage:
   imprint save --all -o FILE
   imprint save --only scripts,cli      Just the scripts, no plugins
   imprint save --only look,bar,plugins
+  imprint save --encrypt -o FILE      Encrypt the archive with age
   imprint restore [FILE]      Pick what to restore, review the changes, confirm
   imprint preview FILE        Show what a restore would change, and stop
   imprint restore FILE --only bar,plugins --dry-run
@@ -290,6 +291,9 @@ do_save() {
   local only=${1:-}
   local output=${2:-}
   local all=${3:-0}
+  local encrypt=${4:-0}
+  local recipient=${5:-}
+  local keep_plaintext=${6:-0}
   banner
   if [[ -z $only && $all -eq 0 ]]; then
     if (( HAVE_GUM )); then
@@ -316,10 +320,14 @@ do_save() {
     fi
   fi
   [[ -n $output ]] || die "no output path"
+  local extra=()
+  (( encrypt == 1 )) && extra+=(--encrypt)
+  [[ -n $recipient ]] && extra+=(-r "$recipient")
+  (( keep_plaintext == 1 )) && extra+=(--keep-plaintext)
   if [[ $all -eq 1 ]]; then
-    engine save --all -o "$output" >/dev/null
+    engine save --all -o "$output" "${extra[@]}" >/dev/null
   else
-    engine save --only "$only" ${SELECTION_FILE:+--select "$SELECTION_FILE"} -o "$output" >/dev/null
+    engine save --only "$only" ${SELECTION_FILE:+--select "$SELECTION_FILE"} -o "$output" "${extra[@]}" >/dev/null
   fi
   [[ -n $SELECTION_FILE ]] && rm -f "$SELECTION_FILE"
 }
@@ -331,6 +339,7 @@ do_restore() {
   local confirm_host=${4:-}
   local upgrade=${5:-0}
   local allow_system=${6:-0}
+  local identity=${7:-}
   banner
   if [[ -z $archive ]]; then
     archive=$(pick_archive) || die "cancelled"
@@ -370,6 +379,7 @@ do_restore() {
   (( allow_system == 1 )) && extra+=(--allow-system)
   # These were parsed and then thrown away on the interactive path.
   [[ -n $confirm_host ]] && extra+=(--confirm-hostname "$confirm_host")
+  [[ -n $identity ]] && extra+=(--identity "$identity")
   [[ -n $SELECTION_FILE ]] && extra+=(--select "$SELECTION_FILE")
 
   # Say exactly what will change before asking for the go-ahead.
@@ -445,11 +455,17 @@ case $cmd in
     only=""
     output=""
     all=0
+    encrypt=0
+    recipient=""
+    keep_plaintext=0
     while [[ $# -gt 0 ]]; do
       case $1 in
         --only) [[ $# -ge 2 ]] || die "--only needs a value"; only=$2; shift 2 ;;
         --all) all=1; shift ;;
         -o|--output) [[ $# -ge 2 ]] || die "--output needs a value"; output=$2; shift 2 ;;
+        --encrypt) encrypt=1; shift ;;
+        -r|--recipient) [[ $# -ge 2 ]] || die "--recipient needs a value"; recipient=$2; shift 2 ;;
+        --keep-plaintext) keep_plaintext=1; shift ;;
         --yes) shift ;;
         *) die "unknown save flag: $1" ;;
       esac
@@ -460,9 +476,12 @@ case $cmd in
       [[ $all -eq 1 ]] && args+=(--all)
       [[ -n $only && $all -eq 0 ]] && args+=(--only "$only")
       [[ -n $output ]] && args+=(-o "$output")
+      [[ $encrypt -eq 1 ]] && args+=(--encrypt)
+      [[ -n $recipient ]] && args+=(-r "$recipient")
+      [[ $keep_plaintext -eq 1 ]] && args+=(--keep-plaintext)
       engine "${args[@]}"
     else
-      do_save "$only" "$output" "$all"
+      do_save "$only" "$output" "$all" "$encrypt" "$recipient" "$keep_plaintext"
     fi
     ;;
   restore)
@@ -472,6 +491,7 @@ case $cmd in
     upgrade=0
     allow_system=0
     confirm_host=""
+    identity=""
     while [[ $# -gt 0 ]]; do
       case $1 in
         --only) [[ $# -ge 2 ]] || die "--only needs a value"; only=$2; shift 2 ;;
@@ -479,6 +499,7 @@ case $cmd in
         --upgrade) upgrade=1; shift ;;
         --allow-system) allow_system=1; shift ;;
         --confirm-hostname) [[ $# -ge 2 ]] || die "--confirm-hostname needs a value"; confirm_host=$2; shift 2 ;;
+        --identity) [[ $# -ge 2 ]] || die "--identity needs a value"; identity=$2; shift 2 ;;
         --yes) shift ;;
         -*) die "unknown restore flag: $1" ;;
         *) archive=$1; shift ;;
@@ -489,10 +510,11 @@ case $cmd in
     [[ $upgrade -eq 1 ]] && extra+=(--upgrade)
     [[ $allow_system -eq 1 ]] && extra+=(--allow-system)
     [[ -n $confirm_host ]] && extra+=(--confirm-hostname "$confirm_host")
+    [[ -n $identity ]] && extra+=(--identity "$identity")
     if [[ -n $only && -n $archive ]]; then
       engine restore "$archive" --only "$only" "${extra[@]}"
     else
-      do_restore "$archive" "$only" "$dry" "$confirm_host" "$upgrade" "$allow_system"
+      do_restore "$archive" "$only" "$dry" "$confirm_host" "$upgrade" "$allow_system" "$identity"
     fi
     ;;
   plan)

--- a/imprint-engine.py
+++ b/imprint-engine.py
@@ -2478,9 +2478,66 @@ def load_manifest(root: Path) -> dict:
     return data
 
 
-def open_imprint(path: Path, tmp: Path) -> Path:
+def age_recipient(explicit: str) -> str:
+    """The age recipient to encrypt to: --recipient, else the default public
+    key. A missing recipient is a clean error, not a half-written archive."""
+    if explicit:
+        return explicit
+    pub = Path.home() / ".config/age/backup-key.pub"
+    if pub.is_file():
+        text = pub.read_text(encoding="utf-8").strip()
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("age1"):
+                return line
+        return text
+    raise SystemExit("no age recipient found; run age-keygen -o backup-key.txt "
+                     "(and put the public key at ~/.config/age/backup-key.pub)")
+
+
+def encrypt_archive(dest: Path, recipient: str, keep_plaintext: bool) -> Path:
+    """Encrypt a finished archive with age, returning the .age path. The
+    plaintext is removed unless keep_plaintext is set."""
+    if not shutil.which("age"):
+        raise SystemExit("age is required for --encrypt; install age "
+                         "(age-keygen ships with it)")
+    enc = Path(str(dest) + ".age")
+    proc = run(["age", "-r", recipient, "-o", str(enc), str(dest)])
+    if proc.returncode != 0:
+        raise SystemExit(f"cannot encrypt {dest}: "
+                         + (proc.stderr or proc.stdout).strip()[:300])
+    if not keep_plaintext:
+        dest.unlink()
+    return enc
+
+
+def decrypt_archive(archive: Path, tmp: Path, identity: str = "") -> Path:
+    """If `archive` is age-encrypted, decrypt it into `tmp` and return the
+    plaintext path; otherwise return `archive` unchanged."""
+    if archive.suffix != ".age":
+        return archive
+    if not shutil.which("age"):
+        raise SystemExit("this archive is age-encrypted and `age` is not "
+                         "installed; install age to decrypt it")
+    ident = Path(identity).expanduser() if identity else (
+        Path.home() / ".config/age/backup-key.txt")
+    if not ident.is_file():
+        raise SystemExit(f"cannot decrypt {archive}: no age identity at {ident}; "
+                         f"run age-keygen -o backup-key.txt and put the key at "
+                         f"~/.config/age/backup-key.txt")
+    plain = tmp / (archive.name[:-4] or "archive.tar.zst")
+    tmp.mkdir(parents=True, exist_ok=True)
+    proc = run(["age", "-d", "-i", str(ident), "-o", str(plain), str(archive)])
+    if proc.returncode != 0:
+        raise SystemExit(f"cannot decrypt {archive}: "
+                         + (proc.stderr or proc.stdout).strip()[:300])
+    return plain
+
+
+def open_imprint(path: Path, tmp: Path, identity: str = "") -> Path:
     if path.is_dir() and (path / "manifest.json").is_file():
         return path
+    path = decrypt_archive(path, tmp, identity)
     extract_archive(path, tmp)
     if (tmp / "manifest.json").is_file():
         return tmp
@@ -2562,6 +2619,7 @@ def cmd_save(args) -> int:
     if dest.suffixes[-2:] != [".tar", ".zst"] and not str(dest).endswith(".tar.zst"):
         dest = dest.with_name(dest.name + ".tar.zst") if dest.suffix == "" else dest
     check_dest(dest, create=not typed)
+    encrypt = bool(getattr(args, "encrypt", False))
     SKIPPED.clear()
     with tempfile.TemporaryDirectory(prefix="imprint-") as tmp:
         staging = Path(tmp) / "imprint"
@@ -2570,7 +2628,7 @@ def cmd_save(args) -> int:
         categories = collect_selected(staging, home, ids, progress)
         manifest = machine_facts()
         manifest["categories"] = {cid: strip_heavy(categories[cid]) for cid in ids}
-        manifest["archiveName"] = dest.name
+        manifest["archiveName"] = dest.name + (".age" if encrypt else "")
         # The archive says what it could not take. Nobody restoring it should
         # have to discover the gap by finding the file missing months later.
         if SKIPPED:
@@ -2581,6 +2639,9 @@ def cmd_save(args) -> int:
         copy_tool(staging)
         progress.update("writing the archive")
         write_archive(staging, dest)
+        if encrypt:
+            recipient = age_recipient(getattr(args, "recipient", "") or "")
+            dest = encrypt_archive(dest, recipient, bool(getattr(args, "keep_plaintext", False)))
         size_now = dest.stat().st_size
         progress.finish(f"Wrote {dest}",
                         f"{human_size(size_now)} \u00b7 {len(ids)} categories")
@@ -3648,7 +3709,7 @@ def cmd_restore(args) -> int:
     ids = parse_only(args.only) if args.only else None
     dry = bool(args.dry_run)
     with tempfile.TemporaryDirectory(prefix="imprint-restore-") as tmp:
-        root = open_imprint(archive, Path(tmp) / "open")
+        root = open_imprint(archive, Path(tmp) / "open", getattr(args, "identity", "") or "")
         manifest = load_manifest(root)
         available = [cid for cid in (manifest.get("categories") or {}) if (root / "categories" / cid).exists()]
         if ids is None:
@@ -4138,8 +4199,7 @@ def cmd_plan(args) -> int:
     else:
         if payload.exists():
             shutil.rmtree(payload)
-        extract_archive(archive, payload)
-        root = payload if (payload / "manifest.json").is_file() else open_imprint(archive, payload)
+        root = open_imprint(archive, payload)
     manifest = load_manifest(root)
     available = [cid for cid in (manifest.get("categories") or {}) if (root / "categories" / cid).exists()]
     ids = parse_only(args.only) if args.only else available
@@ -5071,6 +5131,13 @@ def build_parser() -> argparse.ArgumentParser:
     save.add_argument("-o", "--output", default="")
     save.add_argument("--select", default="",
                       help="JSON from `imprint pick`, to narrow within a category")
+    save.add_argument("--encrypt", action="store_true",
+                      help="encrypt the archive with age after writing it")
+    save.add_argument("-r", "--recipient", default="",
+                      help="age recipient (public key); defaults to "
+                           "~/.config/age/backup-key.pub")
+    save.add_argument("--keep-plaintext", action="store_true",
+                      help="keep the unencrypted .tar.zst alongside the .age file")
     restore = sub.add_parser("restore")
     restore.add_argument("--json", action="store_true", help="print the machine-readable report")
     restore.add_argument("archive")
@@ -5085,6 +5152,9 @@ def build_parser() -> argparse.ArgumentParser:
                          help="apply the system layer (/etc + systemctl enable) with sudo")
     restore.add_argument("--upgrade", action="store_true",
                          help="run `omarchy update -y` before restoring anything")
+    restore.add_argument("--identity", default="",
+                         help="age identity file to decrypt an encrypted archive; "
+                              "defaults to ~/.config/age/backup-key.txt")
     info = sub.add_parser("info")
     info.add_argument("archive")
     info.add_argument("--json", action="store_true")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -925,7 +925,7 @@ class SystemLayerTests(unittest.TestCase):
         real_run, real_open, real_manifest = engine.run, engine.open_imprint, engine.load_manifest
         fake_root = Path(tempfile.mkdtemp())
         (fake_root / "categories/packages").mkdir(parents=True)
-        engine.open_imprint = lambda a, b: fake_root
+        engine.open_imprint = lambda a, b, identity="": fake_root
         engine.load_manifest = lambda r: {"kind": engine.KIND, "home": "/home/x",
                                           "categories": {"packages": {}}}
         touched = []
@@ -1732,6 +1732,107 @@ class InputPathTests(unittest.TestCase):
             with self.assertRaises(SystemExit) as caught:
                 engine.need_file(tmp, "cannot read the selection file")
             self.assertIn("is a directory, not a file", str(caught.exception))
+
+
+class AgeEncryptionTests(unittest.TestCase):
+    def _keypair(self, tmp):
+        """Generate an age keypair, returning (public_key, identity_path)."""
+        import subprocess
+        proc = subprocess.run(["age-keygen"], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        pub = priv = None
+        for line in proc.stdout.splitlines():
+            if line.startswith("# public key: "):
+                pub = line.split(": ", 1)[1]
+            elif line.startswith("AGE-SECRET-KEY-"):
+                priv = line
+        self.assertIsNotNone(pub, proc.stdout)
+        self.assertIsNotNone(priv, proc.stdout)
+        ident = Path(tmp) / "key.txt"
+        ident.write_text(priv + "\n", encoding="utf-8")
+        return pub, ident
+
+    def _archive(self, tmp):
+        """Write a real imprint tar.zst and return its path."""
+        t = Path(tmp)
+        staging = t / "staging"; staging.mkdir()
+        (staging / "manifest.json").write_text(
+            json.dumps({"kind": engine.KIND, "hostname": "x", "categories": {}}),
+            encoding="utf-8")
+        src = t / "a.tar.zst"
+        engine.write_archive(staging, src)
+        return src
+
+    @unittest.skipUnless(shutil.which("age"), "age not installed")
+    def test_encrypt_then_decrypt_round_trips_a_tar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pub, ident = self._keypair(tmp)
+            src = self._archive(tmp)
+            enc = engine.encrypt_archive(src, pub, keep_plaintext=False)
+            self.assertEqual(enc.name, "a.tar.zst.age")
+            self.assertTrue(enc.is_file())
+            self.assertFalse(src.exists())          # plaintext removed by default
+            out = engine.decrypt_archive(enc, Path(tmp) / "out", str(ident))
+            self.assertTrue(out.is_file())
+            import tarfile
+            with tarfile.open(out, "r:*") as tar:
+                names = tar.getnames()
+            self.assertTrue(any(n.endswith("manifest.json") for n in names), names)
+
+    @unittest.skipUnless(shutil.which("age"), "age not installed")
+    def test_keep_plaintext_leaves_the_tar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pub, ident = self._keypair(tmp)
+            src = self._archive(tmp)
+            enc = engine.encrypt_archive(src, pub, keep_plaintext=True)
+            self.assertTrue(enc.is_file())
+            self.assertTrue(src.exists())           # kept alongside
+
+    @unittest.skipUnless(shutil.which("age"), "age not installed")
+    def test_open_imprint_decrypts_an_encrypted_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pub, ident = self._keypair(tmp)
+            src = self._archive(tmp)
+            enc = engine.encrypt_archive(src, pub, keep_plaintext=False)
+            root = engine.open_imprint(enc, Path(tmp) / "open", str(ident))
+            self.assertTrue((root / "manifest.json").is_file())
+
+    @unittest.skipUnless(shutil.which("age"), "age not installed")
+    def test_decrypt_without_identity_is_a_clean_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pub, ident = self._keypair(tmp)
+            src = self._archive(tmp)
+            enc = engine.encrypt_archive(src, pub, keep_plaintext=False)
+            missing = Path(tmp) / "nope" / "key.txt"
+            with self.assertRaises(SystemExit) as caught:
+                engine.decrypt_archive(enc, Path(tmp) / "out", str(missing))
+            self.assertIn("no age identity", str(caught.exception))
+
+    def test_encrypt_without_age_binary_is_a_clean_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "a.tar.zst"; src.write_text("x", encoding="utf-8")
+            old = os.environ.get("PATH")
+            os.environ["PATH"] = str(Path(tmp) / "emptybin")
+            try:
+                with self.assertRaises(SystemExit) as caught:
+                    engine.encrypt_archive(src, "age1whatever", keep_plaintext=False)
+            finally:
+                if old is None: os.environ.pop("PATH", None)
+                else: os.environ["PATH"] = old
+            self.assertIn("age is required", str(caught.exception))
+
+    def test_age_recipient_without_pub_key_is_a_clean_error(self):
+        import pathlib as _pl
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(_pl.Path, "home", return_value=Path(tmp)):
+                with self.assertRaises(SystemExit) as caught:
+                    engine.age_recipient("")
+            self.assertIn("no age recipient found", str(caught.exception))
+            self.assertIn("age-keygen -o backup-key.txt", str(caught.exception))
+
+    def test_age_recipient_explicit_wins(self):
+        self.assertEqual(engine.age_recipient("age1explicit"), "age1explicit")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

An imprint archive carries configs, shell history and identity data, and it is
often copied to a USB stick or relayed through a chat. Today that file is
plaintext — anyone who can read it can read the machine's personality. This
adds opt-in encryption so a backup can travel without exposing its contents.

## Design

Encryption is **opt-in** and adds **zero new hard dependencies**. `age` is an
external binary the user must have only when they use `--encrypt` (or restore
an encrypted archive); the rest of imprint is unchanged.

- `imprint save --encrypt [-r RECIPIENT]` writes the `.tar.zst` as usual, then
  encrypts it with `age -r <recipient>` to `<archive>.tar.zst.age` and removes
  the plaintext — unless `--keep-plaintext` is passed.
- Recipient resolution: explicit `-r`, else `~/.config/age/backup-key.pub` if
  it exists, else a clean error (`no age recipient found; run age-keygen -o
  backup-key.txt`).
- `imprint restore` auto-detects a `.tar.zst.age` and decrypts it with
  `~/.config/age/backup-key.txt` (or `--identity FILE`) into a temp file before
  the normal picker/flow. A missing identity is a clean error, not a traceback.
- `imprint info`, `plan`, `preview`, `verify` and `diff` all decrypt a `.age`
  archive through the same path, so every read command works on an encrypted
  archive without extra flags.

## Implementation

- `age_recipient()`, `encrypt_archive()` and `decrypt_archive()` helpers in
  `imprint-engine.py`.
- `open_imprint()` now takes an optional `identity` and decrypts `.age` archives
  before extraction, so every command that opens an archive inherits the
  behaviour.
- `cmd_save` encrypts after `write_archive` and reports the `.age` path.
- The `imprint` wrapper passes `--encrypt`/`-r`/`--keep-plaintext` and
  `--identity` through.

## Docs + tests

- README documents the flag in the save/restore sections and a new
  "Encrypting archives" section, including that `age` is not a hard dependency.
- Seven new tests cover: encrypt→decrypt round-trip to a valid tar,
  `--keep-plaintext`, `open_imprint` decrypting an encrypted archive, and the
  error paths (no `age` binary, no identity, no recipient).

Baseline: 136 tests pass. After the change: 143 tests pass.
