### PR TITLE
Keep what the submenu picked instead of losing it to a subshell

### DIFF
--- a/imprint
+++ b/imprint
@@ -168,18 +168,26 @@ ids_from_archive_defaults() {
 }
 
 SELECTION_FILE=""
+SELECTED_CATEGORIES=""
 
 # Our own picker: space toggles, space on a row with a submenu walks into it,
 # and the top row selects everything. gum choose can do none of that.
+#
+# Both halves of the answer come back in globals. The categories used to travel
+# on stdout, which meant callers ran this in $(...) -- and the SELECTION_FILE
+# assignment then died with the subshell, so every submenu choice was silently
+# discarded and the engine captured or restored everything. Never call this in
+# a command substitution.
 choose_categories() {
   local header=$1
   local archive=${2:-}
+  SELECTED_CATEGORIES=""
   SELECTION_FILE=$(mktemp -t imprint-selection-XXXXXX.json)
   local args=(pick --header "$header" --action "${PICK_ACTION:-Start backup}")
   [[ -n $archive ]] && args+=(--archive "$archive")
   engine "${args[@]}" > "$SELECTION_FILE" || { rm -f "$SELECTION_FILE"; SELECTION_FILE=""; return 1; }
-  python3 -c 'import json,sys; print(",".join(json.load(open(sys.argv[1]))["categories"]))' \
-    "$SELECTION_FILE"
+  SELECTED_CATEGORIES=$(python3 -c 'import json,sys; print(",".join(json.load(open(sys.argv[1]))["categories"]))' \
+    "$SELECTION_FILE") || { rm -f "$SELECTION_FILE"; SELECTION_FILE=""; return 1; }
 }
 
 pick_archive() {
@@ -294,7 +302,9 @@ do_save() {
   banner
   if [[ -z $only && $all -eq 0 ]]; then
     if (( HAVE_GUM )); then
-      PICK_ACTION="Start backup" only=$(choose_categories "What should this imprint carry?") || die "cancelled"
+      PICK_ACTION="Start backup"
+      choose_categories "What should this imprint carry?" || die "cancelled"
+      only=$SELECTED_CATEGORIES
     else
       only=$(default_selected)
       say "No terminal for the picker; using the default categories."
@@ -348,7 +358,9 @@ do_restore() {
   say "Archive $archive"
   if [[ -z $only ]]; then
     if (( HAVE_GUM )); then
-      PICK_ACTION="Review changes" only=$(choose_categories "What should land on this machine?" "$archive") || die "cancelled"
+      PICK_ACTION="Review changes"
+      choose_categories "What should land on this machine?" "$archive" || die "cancelled"
+      only=$SELECTED_CATEGORIES
     else
       only=$(ids_from_archive_defaults "$archive")
       say "No terminal for the picker; using this archive's default categories."

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1756,5 +1756,97 @@ class VersionTests(unittest.TestCase):
         self.assertIn('imprint = "before 1.0.0"', brief)
 
 
+
+class ShellSelectionTests(unittest.TestCase):
+    """The picker's within-category choices have to survive the trip from the
+    shell wrapper to the engine. They used to be dropped on the floor."""
+
+    STUB = '''#!/usr/bin/env python3
+import json, sys, os
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+log = os.environ["IMPRINT_ARGV_LOG"]
+with open(log, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(sys.argv[1:]) + "\\n")
+if "--select" in sys.argv:
+    spec = json.load(open(sys.argv[sys.argv.index("--select") + 1]))
+    with open(log + ".select", "a", encoding="utf-8") as fh:
+        fh.write(json.dumps([cmd, spec]) + "\\n")
+if cmd == "pick":
+    json.dump({"categories": ["packages", "themes"],
+               "subselections": {"packages": ["ripgrep", "fd"]}}, sys.stdout)
+    sys.stdout.write("\\n")
+elif cmd == "info":
+    json.dump({"categories": {"packages": {}, "themes": {}}}, sys.stdout)
+elif cmd in ("verify", "preview"):
+    sys.stdout.write("ok\\n")
+sys.exit(0)
+'''
+
+    def run_imprint(self, tmp, *argv):
+        import pty, subprocess, threading
+        log = Path(tmp) / "argv.log"
+        stub = Path(tmp) / "imprint-engine.py"
+        stub.write_text(self.STUB, encoding="utf-8")
+        stub.chmod(0o755)
+        script = Path(tmp) / "imprint"
+        shutil.copy2(ROOT / "imprint", script)
+        env = dict(os.environ, IMPRINT_ARGV_LOG=str(log))
+        # The picker only runs on a terminal, so give the script a real one.
+        master, slave = pty.openpty()
+        drain = threading.Thread(target=lambda: self._drain(master), daemon=True)
+        drain.start()
+        try:
+            subprocess.run([str(script), *argv], stdin=slave, stdout=slave,
+                           stderr=slave, env=env, timeout=60)
+        finally:
+            os.close(slave)
+        read = lambda f: [json.loads(line) for line in
+                          f.read_text(encoding="utf-8").splitlines()] if f.exists() else []
+        return read(log), read(Path(str(log) + ".select"))
+
+    @staticmethod
+    def _drain(master):
+        try:
+            while os.read(master, 4096):
+                pass
+        except OSError:
+            pass
+
+    def select_arg(self, call):
+        return call[call.index("--select") + 1] if "--select" in call else None
+
+    def test_save_hands_the_engine_what_the_submenu_picked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out.tar.zst"
+            calls, selects = self.run_imprint(tmp, "save", "-o", str(out))
+            save = [c for c in calls if c and c[0] == "save"]
+            self.assertTrue(save, f"engine save was never called: {calls}")
+            self.assertIn("--select", save[0],
+                          "the submenu's choices never reached the engine")
+            self.assertIn("--only", save[0], "the chosen categories were lost")
+            self.assertEqual("packages,themes", save[0][save[0].index("--only") + 1])
+            picked = [spec for cmd, spec in selects if cmd == "save"]
+            self.assertEqual([{"packages": ["ripgrep", "fd"]}],
+                             [s["subselections"] for s in picked])
+
+    def test_restore_hands_the_engine_what_the_submenu_picked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "some.tar.zst"
+            archive.write_bytes(b"x")
+            calls, selects = self.run_imprint(tmp, "restore", str(archive), "--dry-run")
+            restore = [c for c in calls if c and c[0] == "restore"]
+            self.assertTrue(restore, f"engine restore was never called: {calls}")
+            self.assertIn("--select", restore[0],
+                          "the submenu's choices never reached the engine")
+            self.assertEqual("packages,themes", restore[0][restore[0].index("--only") + 1])
+            # The preview has to narrow the same way, or it promises more than
+            # the restore delivers.
+            for want in ("restore", "preview"):
+                picked = [spec for cmd, spec in selects if cmd == want]
+                self.assertEqual([{"packages": ["ripgrep", "fd"]}],
+                                 [s["subselections"] for s in picked],
+                                 f"{want} did not get the submenu's choices")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
choose_categories set SELECTION_FILE and printed the chosen categories on stdout, so both call sites ran it inside $(...). The categories survived, being the output; the assignment did not, dying with the subshell. In the parent SELECTION_FILE was still empty, ${SELECTION_FILE:+--select ...} expanded to nothing, and the engine saw no --select at all -- so wanted() said yes to everything. Pick twelve packages, get sixty.

Category-level choices still worked, which is why this looked fine: only the narrowing within a category was thrown away, on save and on restore alike, for packages, plugins, themes and scripts.

Return both halves in globals and call the function directly. The temp file gets cleaned up now too, rather than left behind in /tmp.

The two tests drive the real script under a pty against a stub engine and check what the engine is actually handed, since the break was in the plumbing between the two and neither side could see it alone.

Fixes #2