### PR TITLE
Restore shell.json the way Omarchy itself writes it

### DIFF
--- a/imprint-engine.py
+++ b/imprint-engine.py
@@ -3101,7 +3101,22 @@ def restore_look(cat_dir: Path, home: Path, old_home: str, undo: Path, dry: bool
 
 
 def shell_is_running() -> bool:
-    return run(["omarchy", "shell", "-q", "shell", "ping"]).returncode == 0
+    # Not `-q`. That flag is not "quiet" but "always succeed": every failure in
+    # omarchy-shell goes through a fail() that exits 0 under it, so a quiet ping
+    # answers "up" with the shell stopped, unreachable, or the target misspelt.
+    return run(["omarchy", "shell", "shell", "ping"]).returncode == 0
+
+
+def reload_shell_config() -> bool:
+    """Ask a running shell to re-read shell.json.
+
+    The same two calls omarchy-shell-config makes after it writes the file.
+    False means nothing picked the change up -- normally because no shell is
+    running, in which case the next one to start reads the file anyway.
+    """
+    if run(["omarchy", "shell", "shell", "reloadConfig"]).returncode == 0:
+        return True
+    return run(["omarchy", "shell", "shell", "rescanPlugins"]).returncode == 0
 
 
 def restore_bar(cat_dir: Path, home: Path, old_home: str, undo: Path, dry: bool) -> list[str]:
@@ -3110,62 +3125,50 @@ def restore_bar(cat_dir: Path, home: Path, old_home: str, undo: Path, dry: bool)
         # packed relative without leading handling
         matches = list((cat_dir / "files").rglob("shell.json")) if (cat_dir / "files").is_dir() else []
         shell_src = matches[0] if matches else shell_src
-    # Everything except shell.json is a plain file; shell.json needs config-edit.
+    # Everything except shell.json is a plain file; shell.json needs the shell
+    # told about it afterwards.
     others = restore_file_tree(cat_dir, home, old_home, undo, dry,
                                skip_rel=".config/omarchy/shell.json")
     if not shell_src.is_file():
         return others + ["no shell.json in this imprint, bar left alone"]
     dest = home / ".config/omarchy/shell.json"
     if dry:
-        return others + ["shell.json via config-edit"]
+        return others + ["shell.json restored, then the shell reloaded"]
     text = rewrite_text(shell_src.read_text(encoding="utf-8"), old_home, str(home))
 
-    # Never write dest directly while the shell is up. `config-edit` exists to
-    # merge against a live snapshot; writing first would make the snapshot
-    # reflect our own clobber and silently drop every concurrent edit.
-    snap_fd, snap_name = tempfile.mkstemp(prefix="imprint-snap-", suffix=".json")
-    edit_fd, edit_name = tempfile.mkstemp(prefix="imprint-edit-", suffix=".json")
-    os.close(snap_fd)
-    os.close(edit_fd)
-    snap, edited = Path(snap_name), Path(edit_name)
+    # `omarchy shell` forwards <target> <method> to the running shell and has no
+    # config-edit target, so there is nothing to merge against a live snapshot.
+    # Write the file and tell the shell to re-read it, which is how omarchy's own
+    # omarchy-shell-config commits a change. Nothing is lost by not merging: a
+    # restore replaces this file by intent, and the copy it displaces is in undo.
+    if dest.exists() or dest.is_symlink():
+        backup_existing(dest, undo, home)
     try:
-        edited.write_text(text, encoding="utf-8")
-        snap_proc = run(["omarchy", "shell", "config-edit", "snapshot", str(snap)])
-        if snap_proc.returncode == 0:
-            if dest.exists():
-                backup_existing(dest, undo, home)
-            apply = run(
-                [
-                    "omarchy",
-                    "shell",
-                    "config-edit",
-                    "apply",
-                    str(snap),
-                    str(edited),
-                    "--allow-layout-change",
-                ]
-            )
-            if apply.returncode == 0:
-                return others + ["shell.json via config-edit"]
-            detail = (apply.stderr or apply.stdout).strip()[:200]
-            return others + [fail(f"shell.json NOT applied, config-edit refused: {detail}")]
-        # A failed snapshot is not proof the shell is stopped -- it could be an
-        # IPC error or a timeout. Only write directly when the shell really is
-        # down, otherwise refuse and say so.
-        if shell_is_running():
-            detail = (snap_proc.stderr or snap_proc.stdout).strip()[:200]
-            return others + [fail(f"shell.json NOT applied: shell is up but snapshot failed: {detail}")]
-        if dest.exists():
-            backup_existing(dest, undo, home)
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(text, encoding="utf-8")
-        return others + ["shell.json written directly (shell not running)"]
-    finally:
-        for path in (snap, edited):
+        # Land it in one step. A half-written shell.json is read by the live
+        # shell the moment it touches the directory.
+        tmp_fd, tmp_name = tempfile.mkstemp(prefix=".imprint-shell-", suffix=".json",
+                                            dir=str(dest.parent))
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+                handle.write(text)
+            os.chmod(tmp_name, 0o644)
+            # Never write through a symlink at the destination.
+            if dest.is_symlink():
+                dest.unlink()
+            os.replace(tmp_name, dest)
+        except BaseException:
             try:
-                path.unlink()
+                os.unlink(tmp_name)
             except OSError:
                 pass
+            raise
+    except OSError as exc:
+        return others + [fail(f"shell.json NOT restored: {why(exc)}")]
+
+    if reload_shell_config():
+        return others + ["shell.json restored, then the shell reloaded"]
+    return others + ["shell.json restored (no running shell to reload)"]
 
 
 def restore_services(cat_dir: Path, home: Path, old_home: str, undo: Path, dry: bool) -> list[str]:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,6 +5,7 @@ import os
 import sys
 import shutil
 import tempfile
+import types
 import unittest
 from pathlib import Path
 
@@ -1754,6 +1755,121 @@ class VersionTests(unittest.TestCase):
     def test_an_archive_from_before_versions_still_reads(self):
         brief = engine.render_brief({"hostname": "dex", "categories": {}})
         self.assertIn('imprint = "before 1.0.0"', brief)
+
+class ShellJsonRestoreTests(unittest.TestCase):
+    """gh #7: `omarchy shell` is an IPC forwarder taking <target> <method>.
+
+    There is no `config-edit` target, so the old restore asked for one, got
+    'Target not found.', and gave up -- shell.json never restored.
+    """
+
+    def setUp(self):
+        self.real_run = engine.run
+        engine.FAILURES.clear()
+
+    def tearDown(self):
+        engine.run = self.real_run
+        engine.FAILURES.clear()
+
+    def _archive(self, tmp, body='{"bar":{"position":"bottom"}}'):
+        t = Path(tmp)
+        files = t / "cat/files/.config/omarchy"
+        files.mkdir(parents=True)
+        (files / "shell.json").write_text(body, encoding="utf-8")
+        home = t / "home"
+        home.mkdir()
+        undo = t / "undo"
+        undo.mkdir()
+        return t / "cat", home, undo
+
+    def test_restores_shell_json_while_the_shell_is_up(self):
+        calls = []
+        engine.run = lambda cmd, **kw: (calls.append(cmd), types.SimpleNamespace(
+            returncode=0, stdout="ok", stderr=""))[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            cat, home, undo = self._archive(tmp)
+            actions = engine.restore_bar(cat, home, "", undo, False)
+            dest = home / ".config/omarchy/shell.json"
+            self.assertTrue(dest.is_file(), actions)
+            self.assertEqual(json.loads(dest.read_text(encoding="utf-8")),
+                             {"bar": {"position": "bottom"}})
+        self.assertEqual(engine.FAILURES, [])
+
+    def test_never_asks_for_a_config_edit_target(self):
+        calls = []
+        engine.run = lambda cmd, **kw: (calls.append(cmd), types.SimpleNamespace(
+            returncode=0, stdout="ok", stderr=""))[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            cat, home, undo = self._archive(tmp)
+            engine.restore_bar(cat, home, "", undo, False)
+        self.assertFalse([c for c in calls if "config-edit" in c],
+                         f"config-edit is not an omarchy IPC target: {calls}")
+
+    def test_tells_the_live_shell_to_reload(self):
+        calls = []
+        engine.run = lambda cmd, **kw: (calls.append(cmd), types.SimpleNamespace(
+            returncode=0, stdout="ok", stderr=""))[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            cat, home, undo = self._archive(tmp)
+            engine.restore_bar(cat, home, "", undo, False)
+        self.assertTrue(any(c[-2:] == ["shell", "reloadConfig"] for c in calls),
+                        f"a restored shell.json must reach the running shell: {calls}")
+
+    def test_backs_up_what_it_replaces(self):
+        engine.run = lambda cmd, **kw: types.SimpleNamespace(
+            returncode=0, stdout="ok", stderr="")
+        with tempfile.TemporaryDirectory() as tmp:
+            cat, home, undo = self._archive(tmp)
+            dest = home / ".config/omarchy/shell.json"
+            dest.parent.mkdir(parents=True)
+            dest.write_text('{"bar":{"position":"top"}}', encoding="utf-8")
+            engine.restore_bar(cat, home, "", undo, False)
+            saved = list(undo.rglob("shell.json"))
+            self.assertTrue(saved, "the replaced shell.json must be recoverable")
+            self.assertEqual(json.loads(saved[0].read_text(encoding="utf-8")),
+                             {"bar": {"position": "top"}})
+
+    def test_restores_shell_json_with_the_shell_down(self):
+        engine.run = lambda cmd, **kw: types.SimpleNamespace(
+            returncode=1, stdout="", stderr="omarchy-shell is not running")
+        with tempfile.TemporaryDirectory() as tmp:
+            cat, home, undo = self._archive(tmp)
+            actions = engine.restore_bar(cat, home, "", undo, False)
+            dest = home / ".config/omarchy/shell.json"
+            self.assertTrue(dest.is_file(), actions)
+        self.assertEqual(engine.FAILURES, [])
+
+    def test_rewrites_the_old_home_inside_shell_json(self):
+        engine.run = lambda cmd, **kw: types.SimpleNamespace(
+            returncode=0, stdout="ok", stderr="")
+        with tempfile.TemporaryDirectory() as tmp:
+            cat, home, undo = self._archive(tmp, '{"note":"/home/pi/bin/x"}')
+            engine.restore_bar(cat, home, "/home/pi", undo, False)
+            dest = home / ".config/omarchy/shell.json"
+            self.assertEqual(json.loads(dest.read_text(encoding="utf-8")),
+                             {"note": f"{home}/bin/x"})
+
+    def test_a_dry_run_writes_nothing(self):
+        engine.run = lambda cmd, **kw: types.SimpleNamespace(
+            returncode=0, stdout="ok", stderr="")
+        with tempfile.TemporaryDirectory() as tmp:
+            cat, home, undo = self._archive(tmp)
+            engine.restore_bar(cat, home, "", undo, True)
+            self.assertFalse((home / ".config/omarchy/shell.json").exists())
+
+    def test_shell_is_running_does_not_ask_for_quiet_mode(self):
+        """`-q` is not "quiet" -- omarchy-shell's fail() exits 0 under it, so a
+        -q ping succeeds even with the shell down, and the probe is a no-op."""
+        calls = []
+        engine.run = lambda cmd, **kw: (calls.append(cmd), types.SimpleNamespace(
+            returncode=0, stdout="ok", stderr=""))[1]
+        engine.shell_is_running()
+        self.assertEqual(calls, [["omarchy", "shell", "shell", "ping"]])
+
+    def test_shell_is_running_is_false_when_the_shell_is_down(self):
+        engine.run = lambda cmd, **kw: types.SimpleNamespace(
+            returncode=1, stdout="", stderr="omarchy-shell is not running")
+        self.assertFalse(engine.shell_is_running())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
omarchy shell forwards <target> <method> to the running shell. It is not a subcommand dispatcher, and there is no config-edit target, so restore_bar asked for one and got 'Target not found.' every time. It then refused to clobber a live config and gave up, so shell.json never restored -- on any machine, from any archive. The save side was fine, which is why this looked like it worked.

Write the file and ask the shell to re-read it, which is how omarchy-shell-config commits a change and how `omarchy bar` has always worked. Nothing is lost by not merging against a snapshot: a restore replaces this file by intent, and the copy it displaces still goes to the undo dir. The write lands with a rename so a live shell never reads a half-written config.

shell_is_running asked with -q, which is not "quiet" but "always succeed" -- every failure in omarchy-shell exits 0 under it, so the probe answered "up" with the shell stopped. That is what made the direct-write fallback unreachable, so a dead shell got the same refusal as a live one. It asks loudly now.

Checked on omarchy 4.0.2-1, restoring the same archive before and after: the old code left shell.json byte-identical, the new code restored it and the bar moved on screen. With the shell killed, the restore writes the file and says so rather than refusing. imprint undo puts back the previous bytes.

Nine tests cover it, including that no call ever names a config-edit target and that the probe never asks for -q.

Fixes #7