### PR TITLE
Handle missing binaries in run_ok

### DIFF
--- a/imprint-engine.py
+++ b/imprint-engine.py
@@ -477,7 +477,10 @@ def ensure_session_env() -> None:
 
 
 def run_ok(cmd: list[str], cwd: Path | None = None) -> str:
-    proc = run(cmd, cwd=cwd)
+    try:
+        proc = run(cmd, cwd=cwd)
+    except (FileNotFoundError, OSError):
+        return ""
     if proc.returncode != 0:
         return ""
     return proc.stdout


### PR DESCRIPTION
## Summary

- `run_ok` now catches `FileNotFoundError` and `OSError` when a subprocess executable is missing
- Fixes `imprint save --all` aborting during **Toolchains** collection on machines without `cargo`, `go`, or other optional tools installed

## Problem

`collect_toolchains` calls `run_ok(["cargo", "install", "--list"])` (and similar for npm, etc.). On a machine that uses mise but has no Rust toolchain, `subprocess.run` raises `FileNotFoundError` instead of returning a non-zero exit code. That exception was uncaught, so the save failed after collecting most categories.

## Fix

Treat a missing binary the same as a failed command: return an empty string. Mise config and other toolchain metadata still collect normally; absent tools are simply omitted from the archive.

## Test plan

- [x] `imprint save --all` on a machine without `cargo` in PATH completes successfully
- [x] Toolchains category still captures mise config when present

Made with [Cursor](https://cursor.com)